### PR TITLE
#131: Be compatible with `consistent-return` eslint rule (closes #131)

### DIFF
--- a/src/cache/Cache.js
+++ b/src/cache/Cache.js
@@ -64,6 +64,8 @@ export class Cache {
     }
 
     this.log('getAvailablePromise(%o, %s): cache miss', a, String(strategy))
+
+    return undefined
   }
 
   getPromise(a, strategy, fetch) /* Promise[P] */ {


### PR DESCRIPTION
Closes #131

## Test Plan

### tests performed
- `npm run test` ✔️ 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
