### PR TITLE
#141: explicit invalidation of dependent queries should respect ordering (closes #141)

### DIFF
--- a/src/graph/QueryNode.js
+++ b/src/graph/QueryNode.js
@@ -29,8 +29,9 @@ export const Query = ({ fetch: _fetch, cacheStrategy = refetch, __cachePToK: cac
     const A = Object.keys(q.params || {});
     const cache = new ObservableCache({ name: compound });
     const fetch = cacheFetch(_fetch, cacheStrategy, cache);
+    const depth = 0;
     return {
-      [compound]: { fetch, A, compound, upsetParams, cachePToK }
+      [compound]: { fetch, A, compound, upsetParams, cachePToK, depth }
     };
   } else {
     const paramKeys = Object.keys(q.params || {});
@@ -51,6 +52,7 @@ export const Query = ({ fetch: _fetch, cacheStrategy = refetch, __cachePToK: cac
       undefined;
     const cache = new ObservableCache({ name: compound, atok });
     const fetch = cacheFetch(_fetch, cacheStrategy, cache);
+    const depth = Math.max(...depsKeys.map(k => _compound(q.dependencies[k].query).depth)) + 1;
 
     if (depsOnly) {
       // a query with dependencies only (no params)
@@ -84,7 +86,8 @@ export const Query = ({ fetch: _fetch, cacheStrategy = refetch, __cachePToK: cac
         fetch: compose(depsProduct.fetch, map, finalFetch.fetch),
         compound,
         upsetParams,
-        cachePToK
+        cachePToK,
+        depth
       };
 
       return {
@@ -141,7 +144,8 @@ export const Query = ({ fetch: _fetch, cacheStrategy = refetch, __cachePToK: cac
         ),
         compound,
         upsetParams,
-        cachePToK
+        cachePToK,
+        depth
       };
 
       return {

--- a/src/graph/invalidate.js
+++ b/src/graph/invalidate.js
@@ -1,8 +1,13 @@
 import { invalidate as _invalidate, hasObservers } from '../query/invalidate';
-import { queriesAndArgs } from './util';
+import { queriesAndArgs, topoSorted } from './util';
 
 // invalidate (and refetch accordingly) `invalidatePs` for the given `A` arguments object
-export function invalidate(graph, invalidatePs, A) {
+export function invalidate(graph, _invalidatePs, A) {
+  // sorting is needed to ensure that a query is always
+  // invalidated before each one of its dependencies
+  // (otherwise we'd loose the data needed to invalidate the
+  // dependant query, and thus fail to invalidate it)
+  const invalidatePs = topoSorted(graph, _invalidatePs);
   // distribute the arguments following graph edges
   // i.e. produce `args` for each `P` that are valid for the lower level `invalidate` signature
   const { args: invalidateArgs } = queriesAndArgs(graph, invalidatePs, A);

--- a/src/graph/util.js
+++ b/src/graph/util.js
@@ -2,6 +2,7 @@ import t from 'tcomb';
 import pick from 'lodash/pick';
 import assign from 'lodash/assign';
 import findKey from 'lodash/findKey';
+import sortBy from 'lodash/sortBy';
 
 // given a flat `AA` object, e.g.
 //
@@ -40,4 +41,10 @@ export function queriesAndArgs(graph, Ps, A) {
 
 export function findP(graph, fetch) {
   return findKey(graph, { fetch });
+}
+
+// e.g. if `C` depends on `B` depends on `A`
+// given ['A', 'B', 'C'] in any order, returns ['C', 'B', 'A'] (dependants first, root last)
+export function topoSorted(graph, Ps) {
+  return sortBy(Ps, P => -graph[graph[P].compound].depth);
 }

--- a/src/query/invalidate.js
+++ b/src/query/invalidate.js
@@ -19,7 +19,7 @@ function extractDone(fetch, a) {
   }
   const cache = fetch.cache
   const value = cache && cache.get(a)
-  return value && value.done && value.done.hasOwnProperty('done') ? value.done.value : NOT_DONE
+  return value && value.done && value.done.hasOwnProperty('value') ? value.done.value : NOT_DONE
 }
 
 export function invalidate(fetch, a) {

--- a/test/graph/invalidate.test.js
+++ b/test/graph/invalidate.test.js
@@ -279,6 +279,50 @@ describe('graph/invalidate', () => {
       })
     })
 
+    it('should invalidate respecting dependency order 1', () => new Promise((resolve, reject) => {
+      const graph = makeTestGraph()
+
+      query(graph, ['A', 'B'], { token: 'lol' })
+
+      setTimeout(() => {
+        try {
+          expect(graph.B_finalFetch.fetch.cache.map.size).toBe(1);
+          expect(graph.A.fetch.cache.map.size).toBe(1);
+
+          invalidate(graph, ['B', 'A'], { token: 'lol' }) // invalidate
+
+          expect(graph.B_finalFetch.fetch.cache.map.size).toBe(0);
+          expect(graph.A.fetch.cache.map.size).toBe(0);
+
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      }, 5)
+    }))
+
+    it('should invalidate respecting dependency order 2', () => new Promise((resolve, reject) => {
+      const graph = makeTestGraph()
+
+      query(graph, ['A', 'B'], { token: 'lol' })
+
+      setTimeout(() => {
+        try {
+          expect(graph.B_finalFetch.fetch.cache.map.size).toBe(1);
+          expect(graph.A.fetch.cache.map.size).toBe(1);
+
+          invalidate(graph, ['A', 'B'], { token: 'lol' }) // invalidate
+
+          expect(graph.B_finalFetch.fetch.cache.map.size).toBe(0);
+          expect(graph.A.fetch.cache.map.size).toBe(0);
+
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      }, 5)
+    }))
+
   })
 
 })


### PR DESCRIPTION
Closes #141

## Test Plan

### tests performed

- see unit tests
- tested manually on aliniq

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
