### PR TITLE
#166: QueryReturn and CommandReturn types are assignable one to the other (closes #166)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ export * from './cache/strategies';
 type BROKEN_FlattenObject<O extends {}> = { [k in keyof O]: O[k] }[keyof O];
 
 export interface QueryReturn<A, P> {
+  _tag: 'QueryReturn',
   _A: A,
   _P: P
 }
@@ -49,6 +50,7 @@ export function Query<A extends IOTSParams, P, D extends Dependencies>(args: Que
 export type CommandRun<A, P> = (a: A) => Promise<P>;
 
 export interface CommandReturn<A, P> {
+  _tag: 'CommandReturn',
   _A: A,
   _P: P
 }


### PR DESCRIPTION
Closes #166

## Test Plan

### tests performed

Tested in `react-avenger` typings checks

![image](https://user-images.githubusercontent.com/6418684/46532234-4b647f00-c8a0-11e8-9af8-a257ae9bed91.png)

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
