### PR TITLE
backport location blocking features from bento

### DIFF
--- a/dtslint/ts3.5/index.tsx
+++ b/dtslint/ts3.5/index.tsx
@@ -12,7 +12,6 @@ import { param, command } from '../../src/DSL';
 import { observeShallow } from '../../src/observe';
 import { declareQueries } from '../../src/react';
 import * as React from 'react';
-import { constNull } from 'fp-ts/lib/function';
 import { QueryResult } from '../../src/QueryResult';
 import { invalidate } from '../../src/invalidate';
 import { ProductA } from '../../src/util';

--- a/package.json
+++ b/package.json
@@ -17,14 +17,12 @@
   "dependencies": {
     "fp-ts": "^1.19.4",
     "history": "^4.9.0",
-    "lodash.trim": "^4.5.1",
     "qs": "^6.7.0",
     "rxjs": "^6.5.2"
   },
   "devDependencies": {
     "@types/history": "^4.7.2",
     "@types/jest": "^24.0.13",
-    "@types/lodash.trim": "^4.5.6",
     "@types/qs": "^6.5.3",
     "@types/react": "^16.8.19",
     "@types/react-dom": "^16.8.4",

--- a/src/Strategy.ts
+++ b/src/Strategy.ts
@@ -129,7 +129,14 @@ export const setoidShallow = fromEquals(shallowEqual);
 
 export type JSONObject = { [key: string]: JSON };
 export interface JSONArray extends Array<JSON> {}
-export type JSON = null | string | number | boolean | JSONArray | JSONObject;
+export type JSON =
+  | null
+  | undefined
+  | string
+  | number
+  | boolean
+  | JSONArray
+  | JSONObject;
 
 export function JSONEqual<A extends JSON>(a: A, b: A): boolean {
   return JSON.stringify(a) === JSON.stringify(b);

--- a/src/browser/location.ts
+++ b/src/browser/location.ts
@@ -1,15 +1,16 @@
 import { createBrowserHistory } from 'history';
 import { invalidate } from '../invalidate';
 import { query, map } from '../Query';
-import { taskEither, TaskEither } from 'fp-ts/lib/TaskEither';
+import { taskEither, TaskEither, fromIO } from 'fp-ts/lib/TaskEither';
 import { refetch, setoidStrict, setoidJSON } from '../Strategy';
 import { getSetoid } from '../CacheValue';
-import { getStructSetoid, setoidString } from 'fp-ts/lib/Setoid';
+import { getStructSetoid, setoidString, setoidBoolean } from 'fp-ts/lib/Setoid';
 import { command, contramap } from '../command';
 import { Task } from 'fp-ts/lib/Task';
 import { right } from 'fp-ts/lib/Either';
 import { parse, stringify } from 'qs';
 import trim = require('lodash.trim');
+import { IO } from 'fp-ts/lib/IO';
 
 export type HistoryLocation = {
   pathname: string;
@@ -17,7 +18,17 @@ export type HistoryLocation = {
 };
 
 let _setListener = false;
-const history = createBrowserHistory();
+let _historyBlockCallback: ((confirm: boolean) => void) | null = null;
+
+export const requestConfirmationToUpdateLocation = (): (() => void) =>
+  history.block(() => '');
+
+const history = createBrowserHistory({
+  getUserConfirmation(_, callback) {
+    _historyBlockCallback = callback;
+    invalidate({ pendingUpdateLocation });
+  }
+});
 
 /**
  * A query that never fails and returns the current `HistoryLocation`
@@ -80,6 +91,35 @@ export const doUpdateLocation = command(
           })
       )
     )
+);
+
+/**
+ * A query that never fails and returns `true` if there's a pending (blocked) location update
+ */
+export const pendingUpdateLocation = query(() =>
+  taskEither.of<void, boolean>(!!_historyBlockCallback)
+)(
+  refetch<void, void, boolean>(
+    setoidStrict as any,
+    getSetoid<void, boolean>(setoidStrict as any, setoidBoolean)
+  )
+);
+
+/**
+ * A command that never fails and resolves (blocks or unblocks) the pending location update, if any
+ */
+export const doResolvePendingUpdateLocation = command(
+  (confirm: boolean) =>
+    fromIO<void, void>(
+      new IO(() => {
+        const callback = _historyBlockCallback;
+        _historyBlockCallback = null;
+        if (callback) {
+          callback(confirm);
+        }
+      })
+    ),
+  { location, pendingUpdateLocation }
 );
 
 /**

--- a/src/browser/location.ts
+++ b/src/browser/location.ts
@@ -47,12 +47,12 @@ export const location = query(
   }
 )(
   refetch<void, void, HistoryLocation>(
-    setoidStrict as any,
+    setoidStrict,
     getSetoid<void, HistoryLocation>(
-      setoidStrict as any,
+      setoidStrict,
       getStructSetoid<HistoryLocation>({
         pathname: setoidString,
-        search: setoidJSON as any
+        search: setoidJSON
       })
     )
   )
@@ -102,8 +102,8 @@ export const pendingUpdateLocation = query(() =>
   taskEither.of<void, boolean>(!!_historyBlockCallback)
 )(
   refetch<void, void, boolean>(
-    setoidStrict as any,
-    getSetoid<void, boolean>(setoidStrict as any, setoidBoolean)
+    setoidStrict,
+    getSetoid<void, boolean>(setoidStrict, setoidBoolean)
   )
 );
 

--- a/src/react/DirtyFormStatePrompt.tsx
+++ b/src/react/DirtyFormStatePrompt.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { constNull } from 'fp-ts/lib/function';
+import { declareQueries } from './declareQueries';
+// @ts-ignore: to avoid TS4023
+import { DeclareQueriesReturn } from './declareQueries';
+import {
+  pendingUpdateLocation,
+  doResolvePendingUpdateLocation,
+  requestConfirmationToUpdateLocation
+} from '../browser/location';
+
+const queries = declareQueries({ pendingUpdateLocation });
+
+type Props = {
+  renderConfirmation: (
+    onDismiss: () => void,
+    onConfirm: () => void
+  ) => NonNullable<React.ReactNode>;
+} & typeof queries.Props;
+
+class DirtyFormStatePrompt extends React.Component<Props> {
+  unblock: () => void = () => {};
+
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.onBeforeUnload);
+    this.unblock = requestConfirmationToUpdateLocation();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.onBeforeUnload);
+    this.unblock();
+  }
+
+  onBeforeUnload = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = '';
+  };
+
+  render() {
+    return this.props.queries.fold(
+      constNull,
+      constNull,
+      ({ pendingUpdateLocation: isPending }) =>
+        isPending
+          ? this.props.renderConfirmation(
+              () => {
+                doResolvePendingUpdateLocation(false).run();
+              },
+              () => {
+                doResolvePendingUpdateLocation(true).run();
+              }
+            )
+          : null
+    );
+  }
+}
+
+export default queries(DirtyFormStatePrompt);

--- a/src/react/declareQueries.tsx
+++ b/src/react/declareQueries.tsx
@@ -21,7 +21,7 @@ type QueryOutputProps<L, P> = { queries: QueryResult<L, P> };
 
 type InputProps<Props, A> = Omit<Props, 'queries'> & QueryInputProps<A>;
 
-interface DeclareQueriesReturn<A, L, P> {
+export interface DeclareQueriesReturn<A, L, P> {
   <Props extends QueryOutputProps<L, P>>(
     component: React.ComponentType<Props>
   ): React.ComponentType<InputProps<Props, A>>;

--- a/test/location.test.ts
+++ b/test/location.test.ts
@@ -87,6 +87,23 @@ describe('browser/location', () => {
     unblock();
   });
 
+  it('should push to history when running command with different input', async () => {
+    await doUpdateLocation({
+      pathname: '/foo',
+      search: { foo: 'bar' }
+    }).run();
+    const fn = jest.fn();
+    observeStrict(location, undefined).subscribe(fn);
+    await new Promise(r => setTimeout(r));
+    expect(fn.mock.calls.length).toBe(2);
+    await doUpdateLocation({
+      pathname: '/foo2',
+      search: { foo: 'bar2' }
+    }).run();
+    await new Promise(r => setTimeout(r));
+    expect(fn.mock.calls.length).toBe(4);
+  });
+
   it('should not push to history when running command with the same input', async () => {
     await doUpdateLocation({
       pathname: '/foo',

--- a/test/location.test.ts
+++ b/test/location.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/browser/location';
 import { right } from 'fp-ts/lib/Either';
 import { observeStrict } from '../src/observe';
+import { delay } from 'fp-ts/lib/Task';
 
 describe('browser/location', () => {
   it('query/command should parse/stringify the `search` query', async () => {
@@ -94,13 +95,13 @@ describe('browser/location', () => {
     }).run();
     const fn = jest.fn();
     observeStrict(location, undefined).subscribe(fn);
-    await new Promise(r => setTimeout(r));
+    await delay(0, void 0).run();
     expect(fn.mock.calls.length).toBe(2);
     await doUpdateLocation({
       pathname: '/foo2',
       search: { foo: 'bar2' }
     }).run();
-    await new Promise(r => setTimeout(r));
+    await delay(0, void 0).run();
     expect(fn.mock.calls.length).toBe(4);
   });
 
@@ -111,13 +112,13 @@ describe('browser/location', () => {
     }).run();
     const fn = jest.fn();
     observeStrict(location, undefined).subscribe(fn);
-    await new Promise(r => setTimeout(r));
+    await delay(0, void 0).run();
     expect(fn.mock.calls.length).toBe(2);
     await doUpdateLocation({
       pathname: '/foo',
       search: { foo: 'bar' }
     }).run();
-    await new Promise(r => setTimeout(r));
+    await delay(0, void 0).run();
     expect(fn.mock.calls.length).toBe(2);
   });
 


### PR DESCRIPTION
This is the porting of https://github.com/buildo/bento/pull/105 (it should be exactly the same feature, rewritten with new avenger APIs and moved to this repo so that we'll be able to eventually remove all the library code in bento and thus the lib itself)

## Test plan

Added a new test for blocking