### PR TITLE
add react/useQueries hook (closes #216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,30 @@ class MyComponent extends React.PureComponent<Props, State> {
 }
 ```
 
-**NB** both `declareQueries` and `WithQueries` do not support dynamic queries definition (e.g. `declareQueries(someCondition ? { queryA } : { queryA, queryB }`).
+**NB** both `declareQueries` and `WithQueries` do not support dynamic queries definition (e.g. `declareQueries(someCondition ? { queryA } : { queryA, queryB }` will not work).
+
+## useQueries (and useQuery)
+
+alternatively, to avoid unecessary boilerplate, you can use the `useQuery` and `useQueries` hooks:
+
+```tsx
+import { useQuery } from 'avenger/lib/react';
+import { userPreferences } from './queries';
+
+const MyComponent: React.FC<{ userName: string }> = props => {
+  return useQuery(userPreferences, { userName: props.userName }).fold(
+    () => <p>loading</p>,
+    () => <p>there was a problem when fetching preferences</p>,
+    userPreferences => (
+      <p>
+        {props.userName}'s favourite color is {userPreferences.color}
+      </p>
+    )
+  );
+};
+```
+
+**NB** both `useQuery` and `useQueries` support dynamic queries definition (e.g. `useQueries(someCondition ? { queryA } : { queryA, queryB }` will work as expected).
 
 # Navigation
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ class MyComponent extends React.PureComponent<Props, State> {
 
 **NB** both `declareQueries` and `WithQueries` do not support dynamic queries definition (e.g. `declareQueries(someCondition ? { queryA } : { queryA, queryB }` will not work).
 
-## useQueries (and useQuery)
+## useQuery
 
 alternatively, to avoid unecessary boilerplate, you can use the `useQuery` and `useQueries` hooks:
 
@@ -310,6 +310,27 @@ const MyComponent: React.FC<{ userName: string }> = props => {
     userPreferences => (
       <p>
         {props.userName}'s favourite color is {userPreferences.color}
+      </p>
+    )
+  );
+};
+```
+
+## useQueries
+
+```tsx
+import { useQueries } from 'avenger/lib/react';
+
+declare const query1: ObservableQuery<string, unknown, number>;
+declare const query2: ObservableQuery<void, unknown, string>;
+
+const MyComponent: React.FC = props => {
+  return useQueries({ query1, query2 }, { query1: 'query-1-input' }).fold(
+    () => <p>still loading query1 or query2 (or both)</p>,
+    () => <p>there was a problem when fetching either query1 or query2</p>,
+    ({ query1, query2 }) => (
+      <p>
+        {query2}: {query1}
       </p>
     )
   );
@@ -357,8 +378,8 @@ export function viewToLocation(view: CurrentView): HistoryLocation {
   }
 }
 
-const currentView: ObservableQuery = getCurrentView(locationToView);
-export const doUpdateCurrentView: Command = getDoUpdateCurrentView(viewToLocation);
+export const currentView = getCurrentView(locationToView); // ObservableQuery
+export const doUpdateCurrentView = getDoUpdateCurrentView(viewToLocation); // Command
 ```
 
 once you instantiated all the boilerplate needed to instruct Avenger on how to navigate, you can use `currentView` and `doUpdateCurrentView` like they were normal queries and commands (and, in fact, they are..).

--- a/dtslint/ts3.7/index.tsx
+++ b/dtslint/ts3.7/index.tsx
@@ -10,7 +10,12 @@ import {
 import { Strategy, available, expire, refetch } from '../../src/Strategy';
 import { param, command } from '../../src/DSL';
 import { observeShallow } from '../../src/observe';
-import { declareQueries, WithQueries } from '../../src/react';
+import {
+  declareQueries,
+  WithQueries,
+  useQuery,
+  useQueries
+} from '../../src/react';
 import * as React from 'react';
 import { QueryResult } from '../../src/QueryResult';
 import { invalidate } from '../../src/invalidate';
@@ -278,3 +283,13 @@ declare const q3: ObservableQuery<void, string, string>;
     );
   }}
 />;
+
+useQuery(a); // $ExpectError
+useQuery(b); // $ExpectType QueryResult<string, number>
+useQuery(b, 3); // $ExpectError
+useQuery(b, undefined); // $ExpectType QueryResult<string, number>
+
+useQueries({ a }); // $ExpectError
+useQueries({ b }); // $ExpectType QueryResult<string, ProductP<{ b: CachedQuery<void, string, number>; }>>
+useQueries({ b }, { b: 3 }); // $ExpectError
+useQueries({ b }, undefined); // $ExpectType QueryResult<string, ProductP<{ b: CachedQuery<void, string, number>; }>>

--- a/package.json
+++ b/package.json
@@ -16,26 +16,26 @@
   "license": "MIT",
   "dependencies": {
     "fp-ts": "^1.19.5",
-    "history": "^4.9.0",
-    "qs": "^6.7.0",
-    "rxjs": "^6.5.2"
+    "history": "^4.10.1",
+    "qs": "^6.9.1",
+    "rxjs": "^6.5.4"
   },
   "devDependencies": {
-    "@types/history": "^4.7.2",
-    "@types/jest": "^24.0.13",
-    "@types/qs": "^6.5.3",
-    "@types/react": "^16.8.19",
-    "@types/react-dom": "^16.8.4",
+    "@types/history": "^4.7.5",
+    "@types/jest": "^25.1.4",
+    "@types/qs": "^6.9.1",
+    "@types/react": "^16.9.23",
+    "@types/react-dom": "^16.9.5",
     "dtslint": "github:gcanti/dtslint",
     "fast-check": "^1.17.0",
     "fp-ts-laws": "0.1.0",
-    "jest": "^24.8.0",
+    "jest": "^25.1.0",
     "prettier": "^1.18.0",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
     "react-testing-library": "^6.1.2",
-    "ts-jest": "^24.0.2",
-    "typescript": "^3.6.4"
+    "ts-jest": "^25.2.1",
+    "typescript": "^3.8.3"
   },
   "files": [
     "lib"

--- a/src/react/declareQueries.tsx
+++ b/src/react/declareQueries.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { QueryResult, loading, success } from '../QueryResult';
+import { QueryResult } from '../QueryResult';
 import {
   ObservableQueries,
   EnforceNonEmptyRecord,
@@ -7,6 +7,7 @@ import {
   ProductL,
   ProductP
 } from '../util';
+import { defaultMonoidResult } from './util';
 import { Monoid } from 'fp-ts/lib/Monoid';
 import { observable } from '../Observable';
 import { observeShallow } from '../observe';
@@ -27,16 +28,6 @@ export interface DeclareQueriesReturn<A, L, P> {
   ): React.ComponentType<InputProps<Props, A>>;
   InputProps: QueryInputProps<A>;
   Props: QueryOutputProps<L, P>;
-}
-
-function defaultMonoidResult<L, P>() {
-  return {
-    empty: loading,
-    concat: (a: QueryResult<L, P>, b: QueryResult<L, P>) =>
-      a.type === 'Success' && b.type === 'Loading'
-        ? success<L, P>(a.value, true)
-        : b
-  };
 }
 
 /**

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,2 +1,3 @@
 export * from './declareQueries';
 export * from './WithQueries';
+export * from './useQueries';

--- a/src/react/useQueries.ts
+++ b/src/react/useQueries.ts
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { Monoid } from 'fp-ts/lib/Monoid';
+import { Option, fromNullable } from 'fp-ts/lib/Option';
+import { QueryResult } from '../QueryResult';
+import { product, ObservableQuery } from '../Query';
+import {
+  EnforceNonEmptyRecord,
+  ObservableQueries,
+  ProductL,
+  ProductP,
+  ProductA,
+  VoidInputObservableQueries
+} from '../util';
+import { defaultMonoidResult } from './util';
+import { observable } from '../Observable';
+import { observeShallow } from '../observe';
+import { setoidShallow } from '../Strategy';
+
+function usePrevious<T>(value: T): Option<T> {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  });
+  return fromNullable(ref.current);
+}
+
+/**
+ * A React hook to observe an `ObservableQuery`
+ *
+ * @param query an `ObservableQueries`
+ * @param params input values for the query
+ * @param resultMonoid an optional monoid used to aggregate `QueryResult`s
+ * @returns the latest `QueryResult` to operate upon
+ *
+ * @example
+ * useQuery(randomQuery, randomQueryParams).fold(
+ *   () => "load",
+ *   () => "failed",
+ *   (randomQueryResult) => randomQueryResult
+ * )
+ */
+export function useQuery<A extends void, L, P>(
+  query: ObservableQuery<A, L, P>,
+  params?: A,
+  resultMonoid?: Monoid<QueryResult<L, P>>
+): QueryResult<L, P>;
+export function useQuery<A, L, P>(
+  query: ObservableQuery<A, L, P>,
+  params: A,
+  resultMonoid?: Monoid<QueryResult<L, P>>
+): QueryResult<L, P>;
+export function useQuery<A, L, P>(
+  query: ObservableQuery<A, L, P>,
+  params: A,
+  resultMonoid?: Monoid<QueryResult<L, P>>
+): QueryResult<L, P> {
+  const _resultMonoid = resultMonoid || defaultMonoidResult<L, P>();
+
+  const [state, setState] = React.useState<QueryResult<L, P>>(
+    _resultMonoid.empty
+  );
+
+  const previousInput = usePrevious(params);
+  const [inputEquality, setInputEquality] = React.useState(0);
+
+  React.useEffect(() => {
+    const inputChanged = previousInput.fold(
+      false,
+      previousInput => !query.inputSetoid.equals(previousInput, params)
+    );
+    if (inputChanged) {
+      setInputEquality(inputEquality + 1);
+    }
+  });
+
+  React.useEffect(() => {
+    const subscription = observable
+      .map(observeShallow(query, params), r => _resultMonoid.concat(state, r))
+      .subscribe(setState);
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [inputEquality, query, setState]);
+
+  return state;
+}
+
+/**
+ * A React hook to observe a record of `ObservableQueries`
+ *
+ * @param queries a record of `ObservableQueries`
+ * @param params a record of inputs for the queries
+ * @param resultMonoid an optional monoid used to aggregate `QueryResult`s
+ * @returns the latest `QueryResult` to operate upon
+ *
+ * @example
+ * useQueries(
+ *   { randomQuery },
+ *   { randomQuery: randomQueryParams }
+ * ).fold(
+ *   () => "load",
+ *   () => "failed",
+ *   ({ randomQuery: randomQueryResult }) => randomQueryResult
+ * )
+ */
+export function useQueries<R extends VoidInputObservableQueries>(
+  queries: EnforceNonEmptyRecord<R>,
+  input?: ProductA<R>,
+  resultMonoid?: Monoid<QueryResult<ProductL<R>, ProductP<R>>>
+): QueryResult<ProductL<R>, ProductP<R>>;
+export function useQueries<R extends ObservableQueries>(
+  queries: EnforceNonEmptyRecord<R>,
+  input: ProductA<R>,
+  resultMonoid?: Monoid<QueryResult<ProductL<R>, ProductP<R>>>
+): QueryResult<ProductL<R>, ProductP<R>>;
+export function useQueries<R extends ObservableQueries>(
+  queries: EnforceNonEmptyRecord<R>,
+  params?: ProductA<R>,
+  resultMonoid?: Monoid<QueryResult<ProductL<R>, ProductP<R>>>
+): QueryResult<ProductL<R>, ProductP<R>> {
+  const previousQueries = usePrevious(queries);
+  const [queriesEquality, setQueriesEquality] = React.useState(0);
+  const queryProduct = React.useMemo(() => product(queries), [queriesEquality]);
+  React.useEffect(() => {
+    const queriesChanged = previousQueries.fold(
+      false,
+      previousQueries => !setoidShallow.equals(previousQueries, queries)
+    );
+    if (queriesChanged) {
+      setQueriesEquality(queriesEquality + 1);
+    }
+  });
+
+  return useQuery(queryProduct, (params || {}) as any, resultMonoid);
+}
+
+export default useQueries;

--- a/src/react/util.ts
+++ b/src/react/util.ts
@@ -1,0 +1,11 @@
+import { QueryResult, loading, success } from '../QueryResult';
+
+export function defaultMonoidResult<L, P>() {
+  return {
+    empty: loading,
+    concat: (a: QueryResult<L, P>, b: QueryResult<L, P>) =>
+      a.type === 'Success' && b.type === 'Loading'
+        ? success<L, P>(a.value, true)
+        : b
+  };
+}

--- a/test/CacheValue.test.ts
+++ b/test/CacheValue.test.ts
@@ -22,7 +22,7 @@ function getPending<L, A>(
   leftArb: fc.Arbitrary<L>,
   rightArb: fc.Arbitrary<A>
 ): fc.Arbitrary<CacheValue<L, A>> {
-  return fc.oneof(
+  return fc.oneof<fc.Arbitrary<CacheValue<L, A>>[]>(
     leftArb.map(l => cacheValuePending(Promise.resolve(left(l)), new Date())),
     rightArb.map(r => cacheValuePending(Promise.resolve(right(r)), new Date()))
   );
@@ -42,7 +42,7 @@ function getCacheValue<L, A>(
   leftArb: fc.Arbitrary<L>,
   rightArb: fc.Arbitrary<A>
 ): fc.Arbitrary<CacheValue<L, A>> {
-  return fc.oneof(
+  return fc.oneof<fc.Arbitrary<CacheValue<L, A>>[]>(
     getInitial(rightArb),
     getPending(leftArb, rightArb),
     getError(leftArb),

--- a/test/QueryResult.test.ts
+++ b/test/QueryResult.test.ts
@@ -32,7 +32,7 @@ function getQueryResult<L, A>(
   leftArb: fc.Arbitrary<L>,
   rightArb: fc.Arbitrary<A>
 ): fc.Arbitrary<QueryResult<L, A>> {
-  return fc.oneof(
+  return fc.oneof<fc.Arbitrary<QueryResult<L, A>>[]>(
     getLoading(rightArb),
     getFailure(leftArb),
     getSuccess(rightArb)

--- a/test/WithQueries.test.tsx
+++ b/test/WithQueries.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { render, waitForElement, cleanup } from 'react-testing-library';
+import { queryStrict, refetch, invalidate } from '../src/DSL';
+import { taskEither } from 'fp-ts/lib/TaskEither';
+import { WithQueries } from '../src/react';
+import { QueryResult } from '../src/QueryResult';
+
+describe('declareQueries', () => {
+  it('should work', async () => {
+    const foo = queryStrict(() => taskEither.of<void, string>('foo'), refetch);
+    const Foo = () => (
+      <WithQueries
+        queries={{ foo }}
+        render={queries =>
+          queries.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => foo
+          )
+        }
+      />
+    );
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('foo'));
+    cleanup();
+  });
+
+  it('should rerender after an invalidate', async () => {
+    const res = { value: 'foo' };
+    const foof = jest.fn(() => taskEither.of<void, string>(res.value));
+    const foo = queryStrict(foof, refetch);
+    const renderf = jest.fn(
+      (queries: QueryResult<void, { foo: typeof foo._P }>) =>
+        queries.fold(
+          () => 'loading',
+          () => 'failure',
+          ({ foo }) => foo
+        )
+    );
+    const Foo = () => <WithQueries queries={{ foo }} render={renderf} />;
+
+    const element = React.createElement(Foo);
+    const { getByText, rerender } = await render(element);
+    await waitForElement(() => getByText('foo'));
+    // why 3 and not 2?
+    // Currently WithQueries (implemented using declareQueries) subscribes in componentDidMount, after
+    // the first render which has already happened using monoidResult.empty as query result.
+    // Since we a) don't have a way of comparing result (i.e. no resultSetoid) and b) it's unsafe
+    // to call subscribe and potentially trigger a setState before the component is mounted,
+    // this is expected
+    expect(renderf.mock.calls.length).toBe(3);
+    expect(foof.mock.calls.length).toBe(1);
+    res.value = 'bar';
+    await invalidate({ foo }).run();
+    await rerender(element);
+    await waitForElement(() => getByText('bar'));
+    expect(renderf.mock.calls.length).toBe(5); // Why 5 and not 4? See comment above
+    expect(foof.mock.calls.length).toBe(2);
+    cleanup();
+  });
+
+  it('should re-subscribe when input changes', async () => {
+    const foo = queryStrict(
+      (a: string) => taskEither.of<void, number>(a.length),
+      refetch
+    );
+    const Foo = () => {
+      const [a, setA] = React.useState('foo');
+      React.useEffect(() => {
+        setTimeout(() => setA('foos'), 10);
+      }, []);
+      return (
+        <WithQueries
+          queries={{ foo }}
+          params={{ foo: a }}
+          render={queries =>
+            queries.fold(
+              () => 'loading',
+              () => 'failure',
+              ({ foo }) => String(foo)
+            )
+          }
+        />
+      );
+    };
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('4'));
+    cleanup();
+  });
+
+  it('(currently) does NOT re-subscribe when queries change', async () => {
+    const fooA = queryStrict(
+      () => taskEither.of<void, string>('fooA'),
+      refetch
+    );
+    const fooB = queryStrict(
+      () => taskEither.of<void, string>('fooB'),
+      refetch
+    );
+    function Foo() {
+      const [b, setB] = React.useState(false);
+      React.useEffect(() => {
+        setTimeout(() => setB(true), 10);
+      }, []);
+      return (
+        <WithQueries
+          queries={{ foo: b ? fooB : fooA }}
+          render={queries =>
+            queries.fold(
+              () => 'loading',
+              () => 'failure',
+              ({ foo }) => foo
+            )
+          }
+        />
+      );
+    }
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('fooB'), { timeout: 500 }).catch(() =>
+      waitForElement(() => getByText('fooA'))
+    );
+    cleanup();
+  });
+});

--- a/test/WithQueries.test.tsx
+++ b/test/WithQueries.test.tsx
@@ -49,14 +49,14 @@ describe('declareQueries', () => {
     // Since we a) don't have a way of comparing result (i.e. no resultSetoid) and b) it's unsafe
     // to call subscribe and potentially trigger a setState before the component is mounted,
     // this is expected
-    expect(renderf.mock.calls.length).toBe(3);
-    expect(foof.mock.calls.length).toBe(1);
+    expect(renderf).toHaveBeenCalledTimes(3);
+    expect(foof).toHaveBeenCalledTimes(1);
     res.value = 'bar';
     await invalidate({ foo }).run();
     await rerender(element);
     await waitForElement(() => getByText('bar'));
-    expect(renderf.mock.calls.length).toBe(5); // Why 5 and not 4? See comment above
-    expect(foof.mock.calls.length).toBe(2);
+    expect(renderf).toHaveBeenCalledTimes(5); // Why 5 and not 4? See comment above
+    expect(foof).toHaveBeenCalledTimes(2);
     cleanup();
   });
 

--- a/test/declareQueries.test.tsx
+++ b/test/declareQueries.test.tsx
@@ -52,14 +52,14 @@ describe('declareQueries', () => {
     // Since we a) don't have a way of comparing result (i.e. no resultSetoid) and b) it's unsafe
     // to call subscribe and potentially trigger a setState before the component is mounted,
     // this is expected
-    expect(Foo_.mock.calls.length).toBe(3);
-    expect(foof.mock.calls.length).toBe(1);
+    expect(Foo_).toHaveBeenCalledTimes(3);
+    expect(foof).toHaveBeenCalledTimes(1);
     res.value = 'bar';
     await invalidate({ foo }).run();
     await rerender(element);
     await waitForElement(() => getByText('bar'));
-    expect(Foo_.mock.calls.length).toBe(5); // why 5 and not 4? See comment above
-    expect(foof.mock.calls.length).toBe(2);
+    expect(Foo_).toHaveBeenCalledTimes(5); // why 5 and not 4? See comment above
+    expect(foof).toHaveBeenCalledTimes(2);
     cleanup();
   });
 

--- a/test/declareQueries.test.tsx
+++ b/test/declareQueries.test.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { render, waitForElement, cleanup } from 'react-testing-library';
+import { queryStrict, refetch, invalidate } from '../src/DSL';
+import { taskEither } from 'fp-ts/lib/TaskEither';
+import { declareQueries } from '../src/react';
+
+describe('declareQueries', () => {
+  it('should work', async () => {
+    const foo = queryStrict(() => taskEither.of<void, string>('foo'), refetch);
+    const queries = declareQueries({ foo });
+    const Foo = queries((props: typeof queries.Props) => {
+      return (
+        <>
+          {props.queries.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => foo
+          )}
+        </>
+      );
+    });
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('foo'));
+    cleanup();
+  });
+
+  it('should rerender after an invalidate', async () => {
+    const res = { value: 'foo' };
+    const foof = jest.fn(() => taskEither.of<void, string>(res.value));
+    const foo = queryStrict(foof, refetch);
+    const queries = declareQueries({ foo });
+    const Foo_ = jest.fn((props: typeof queries.Props) => {
+      return (
+        <>
+          {props.queries.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => foo
+          )}
+        </>
+      );
+    });
+    const Foo = queries(Foo_);
+
+    const element = React.createElement(Foo);
+    const { getByText, rerender } = await render(element);
+    await waitForElement(() => getByText('foo'));
+    // why 3 and not 2?
+    // Currently declareQueries subscribes in componentDidMount, after
+    // the first render which has already happened using monoidResult.empty as query result.
+    // Since we a) don't have a way of comparing result (i.e. no resultSetoid) and b) it's unsafe
+    // to call subscribe and potentially trigger a setState before the component is mounted,
+    // this is expected
+    expect(Foo_.mock.calls.length).toBe(3);
+    expect(foof.mock.calls.length).toBe(1);
+    res.value = 'bar';
+    await invalidate({ foo }).run();
+    await rerender(element);
+    await waitForElement(() => getByText('bar'));
+    expect(Foo_.mock.calls.length).toBe(5); // why 5 and not 4? See comment above
+    expect(foof.mock.calls.length).toBe(2);
+    cleanup();
+  });
+
+  it('should re-subscribe when input changes', async () => {
+    const foo = queryStrict(
+      (a: string) => taskEither.of<void, number>(a.length),
+      refetch
+    );
+    const queries = declareQueries({ foo });
+    const Foo = queries((props: typeof queries.Props) => {
+      return (
+        <>
+          {props.queries.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => String(foo)
+          )}
+        </>
+      );
+    });
+    const FooParent = () => {
+      const [a, setA] = React.useState('foo');
+      React.useEffect(() => {
+        setTimeout(() => setA('foos'), 10);
+      }, []);
+
+      return <Foo queries={{ foo: a }} />;
+    };
+
+    const { getByText } = await render(<FooParent />);
+    await waitForElement(() => getByText('4'));
+    cleanup();
+  });
+});

--- a/test/useQueries.test.tsx
+++ b/test/useQueries.test.tsx
@@ -45,14 +45,14 @@ describe('useQueries', () => {
     const element = React.createElement(Foo);
     const { getByText, rerender } = await render(element);
     await waitForElement(() => getByText('foo'));
-    expect(Foo.mock.calls.length).toBe(2);
-    expect(foof.mock.calls.length).toBe(1);
+    expect(Foo).toHaveBeenCalledTimes(2);
+    expect(foof).toHaveBeenCalledTimes(1);
     res.value = 'bar';
     await invalidate({ foo }).run();
     await rerender(element);
     await waitForElement(() => getByText('bar'));
-    expect(Foo.mock.calls.length).toBe(4);
-    expect(foof.mock.calls.length).toBe(2);
+    expect(Foo).toHaveBeenCalledTimes(4);
+    expect(foof).toHaveBeenCalledTimes(2);
     cleanup();
   });
 

--- a/test/useQueries.test.tsx
+++ b/test/useQueries.test.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { render, waitForElement, cleanup } from 'react-testing-library';
+import { queryStrict, refetch, invalidate } from '../src/DSL';
+import { taskEither } from 'fp-ts/lib/TaskEither';
+import { useQueries, useQuery } from '../src/react';
+
+describe('useQueries', () => {
+  it('should work', async () => {
+    const foo = queryStrict(() => taskEither.of<void, string>('foo'), refetch);
+    function Foo() {
+      const f = useQueries({ foo });
+      return (
+        <>
+          {f.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => foo
+          )}
+        </>
+      );
+    }
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('foo'));
+    cleanup();
+  });
+
+  it('should rerender after an invalidate', async () => {
+    const res = { value: 'foo' };
+    const foof = jest.fn(() => taskEither.of<void, string>(res.value));
+    const foo = queryStrict(foof, refetch);
+    const Foo = jest.fn(() => {
+      const f = useQueries({ foo });
+      return (
+        <>
+          {f.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => foo
+          )}
+        </>
+      );
+    });
+
+    const element = React.createElement(Foo);
+    const { getByText, rerender } = await render(element);
+    await waitForElement(() => getByText('foo'));
+    expect(Foo.mock.calls.length).toBe(2);
+    expect(foof.mock.calls.length).toBe(1);
+    res.value = 'bar';
+    await invalidate({ foo }).run();
+    await rerender(element);
+    await waitForElement(() => getByText('bar'));
+    expect(Foo.mock.calls.length).toBe(4);
+    expect(foof.mock.calls.length).toBe(2);
+    cleanup();
+  });
+
+  it('should re-subscribe when input changes', async () => {
+    const foo = queryStrict(
+      (a: string) => taskEither.of<void, number>(a.length),
+      refetch
+    );
+    function Foo() {
+      const [a, setA] = React.useState('foo');
+      React.useEffect(() => {
+        setTimeout(() => setA('foos'), 10);
+      }, []);
+      const f = useQueries({ foo }, { foo: a });
+      return (
+        <>
+          {f.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => String(foo)
+          )}
+        </>
+      );
+    }
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('4'));
+    cleanup();
+  });
+
+  it('should re-subscribe when queries change', async () => {
+    const fooA = queryStrict(
+      () => taskEither.of<void, string>('fooA'),
+      refetch
+    );
+    const fooB = queryStrict(
+      () => taskEither.of<void, string>('fooB'),
+      refetch
+    );
+    function Foo() {
+      const [b, setB] = React.useState(false);
+      React.useEffect(() => {
+        setTimeout(() => setB(true), 10);
+      }, []);
+      const f = useQueries({ foo: b ? fooB : fooA });
+      return (
+        <>
+          {f.fold(
+            () => 'loading',
+            () => 'failure',
+            ({ foo }) => foo
+          )}
+        </>
+      );
+    }
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('fooB'));
+    cleanup();
+  });
+});
+
+describe('useQuery', () => {
+  it('should re-subscribe when query changes', async () => {
+    const fooA = queryStrict(
+      () => taskEither.of<void, string>('fooA'),
+      refetch
+    );
+    const fooB = queryStrict(
+      () => taskEither.of<void, string>('fooB'),
+      refetch
+    );
+    function Foo() {
+      const [b, setB] = React.useState(false);
+      React.useEffect(() => {
+        setTimeout(() => setB(true), 10);
+      }, []);
+      const f = useQuery(b ? fooB : fooA);
+      return (
+        <>
+          {f.fold(
+            () => 'loading',
+            () => 'failure',
+            foo => foo
+          )}
+        </>
+      );
+    }
+
+    const { getByText } = await render(<Foo />);
+    await waitForElement(() => getByText('fooB'));
+    cleanup();
+  });
+});


### PR DESCRIPTION
Second take, this time comes with some tests.

I also added small test suites for the declareQueries/WithQueries variants (and note that there are slight differences in behavior between the 3, which are still acceptable IMO)

Also briefly tested on a real project